### PR TITLE
feat: wire conduit-ui/pr and complete Review::analyze() pipeline

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
         "illuminate/contracts": "^12.0 || ^13.0",
         "illuminate/support": "^12.0 || ^13.0",
         "laravel/ai": "^0.3",
+        "conduit-ui/pr": "^1.0",
         "nikic/php-parser": "^5.0",
         "saloonphp/saloon": "^3.0"
     },

--- a/src/Review.php
+++ b/src/Review.php
@@ -2,6 +2,15 @@
 
 namespace TheShit\Review;
 
+use ConduitUI\Pr\DataTransferObjects\File;
+use ConduitUI\Pr\PullRequests;
+use TheShit\Review\Analyzers\Classifier;
+use TheShit\Review\Analyzers\ConventionChecker;
+use TheShit\Review\Analyzers\JudgmentCall;
+use TheShit\Review\Analyzers\RiskAssessor;
+use TheShit\Review\Contracts\Rule;
+use TheShit\Review\Enums\Verdict;
+
 final class Review
 {
     private ?string $conventions = null;
@@ -11,6 +20,9 @@ final class Review
 
     /** @var string[] */
     private array $dependents = [];
+
+    /** @var Rule[] */
+    private array $rules = [];
 
     private bool $includeJudgment = true;
 
@@ -51,6 +63,16 @@ final class Review
         return $this;
     }
 
+    /**
+     * @param  Rule[]  $rules
+     */
+    public function withRules(array $rules): self
+    {
+        $this->rules = $rules;
+
+        return $this;
+    }
+
     public function withoutJudgment(): self
     {
         $this->includeJudgment = false;
@@ -60,7 +82,150 @@ final class Review
 
     public function analyze(): ReviewResult
     {
-        // Pipeline implementation in issues #2-10
-        throw new \RuntimeException('Review pipeline not yet implemented. See issues #2-10.');
+        // 1. Fetch PR data via conduit-ui/pr
+        $pr = PullRequests::find($this->repo, $this->prNumber);
+        $files = $pr->files();
+        $filePaths = array_map(fn (File $f): string => $f->filename, $files);
+
+        // 2. Classify
+        $classification = (new Classifier)->classify(
+            $pr->data->title,
+            $pr->data->body ?? '',
+            $filePaths,
+        );
+
+        // 3. Risk assessment
+        $totalAdditions = 0;
+        $totalDeletions = 0;
+
+        foreach ($files as $file) {
+            $totalAdditions += $file->additions;
+            $totalDeletions += $file->deletions;
+        }
+
+        $criticalPaths = config("review.repos.{$this->repo}.critical_paths")
+            ?? config('review.critical_paths', []);
+
+        $riskAssessor = new RiskAssessor($criticalPaths);
+        $riskResult = $riskAssessor->assess(
+            $filePaths,
+            [], // structural changes require file-at-ref support (#10 follow-up)
+            $classification,
+            $totalAdditions,
+            $totalDeletions,
+        );
+
+        // 4. Convention checking
+        $findings = [];
+
+        if ($this->rules !== []) {
+            $patches = $this->extractPatches($files);
+            $findings = (new ConventionChecker($this->rules))->checkAll($patches);
+        }
+
+        // 5. Judgment call (optional)
+        if ($this->includeJudgment) {
+            $patches = $this->extractPatches($files);
+            $llmFindings = (new JudgmentCall)->call(
+                $classification,
+                $riskResult['risk'],
+                [],
+                $findings,
+                $patches,
+                $this->conventions,
+            );
+
+            $findings = [...$findings, ...$llmFindings];
+        }
+
+        // 6. Build result
+        return new ReviewResult(
+            classification: $classification,
+            risk: $riskResult['risk'],
+            blastRadius: $riskResult['blast_radius'],
+            findings: collect($findings),
+            summary: $this->buildSummary($classification, $riskResult, $findings),
+            repo: $this->repo,
+            prNumber: $this->prNumber,
+        );
+    }
+
+    /**
+     * Analyze and post the review to GitHub.
+     */
+    public function reviewAndPost(): ReviewResult
+    {
+        $result = $this->analyze();
+        $pr = PullRequests::find($this->repo, $this->prNumber);
+
+        $verdict = $result->verdict();
+        $body = $result->summary;
+
+        if ($result->findings->isNotEmpty()) {
+            $body .= "\n\n### Findings\n";
+
+            foreach ($result->findings as $finding) {
+                if ($finding->aboveThreshold()) {
+                    $location = $finding->file !== '' ? " (`{$finding->file}`)" : '';
+                    $body .= "- **{$finding->severity->value}**{$location}: {$finding->message}\n";
+                }
+            }
+        }
+
+        match ($verdict) {
+            Verdict::Approve => $pr->approve($body)->submit(),
+            Verdict::RequestChanges => $pr->requestChanges($body)->submit(),
+            Verdict::Comment => $pr->review()->comment($body)->submit(),
+        };
+
+        return $result;
+    }
+
+    /**
+     * @param  File[]  $files
+     * @return array<string, string>
+     */
+    private function extractPatches(array $files): array
+    {
+        $patches = [];
+
+        foreach ($files as $file) {
+            if ($file->patch !== null) {
+                $patches[$file->filename] = $file->patch;
+            }
+        }
+
+        return $patches;
+    }
+
+    /**
+     * @param  array{risk: Enums\Risk, blast_radius: string[], signals: string[]}  $riskResult
+     * @param  Finding[]  $findings
+     */
+    private function buildSummary(Enums\Classification $classification, array $riskResult, array $findings): string
+    {
+        $parts = [];
+        $parts[] = "**{$classification->value}** PR — risk: **{$riskResult['risk']->value}**";
+
+        if ($riskResult['signals'] !== []) {
+            $parts[] = 'Signals: '.implode(', ', array_slice($riskResult['signals'], 0, 5));
+        }
+
+        $bugCount = count(array_filter($findings, fn (Finding $f): bool => $f->severity === Enums\Severity::Bug && $f->aboveThreshold()));
+        $conventionCount = count(array_filter($findings, fn (Finding $f): bool => $f->severity === Enums\Severity::Convention && $f->aboveThreshold()));
+
+        if ($bugCount > 0) {
+            $parts[] = "{$bugCount} bug(s) found";
+        }
+
+        if ($conventionCount > 0) {
+            $parts[] = "{$conventionCount} convention violation(s)";
+        }
+
+        if ($bugCount === 0 && $conventionCount === 0) {
+            $parts[] = 'No issues found';
+        }
+
+        return implode('. ', $parts).'.';
     }
 }

--- a/tests/Feature/ReviewPipelineTest.php
+++ b/tests/Feature/ReviewPipelineTest.php
@@ -1,0 +1,189 @@
+<?php
+
+use ConduitUi\GitHubConnector\Connector;
+use ConduitUI\Pr\PullRequests;
+use Saloon\Http\Faking\MockClient;
+use Saloon\Http\Faking\MockResponse;
+use TheShit\Review\Analyzers\JudgmentAgent;
+use TheShit\Review\Enums\Classification;
+use TheShit\Review\Enums\Verdict;
+use TheShit\Review\Review;
+use TheShit\Review\Rules\ForbiddenPattern;
+
+function mockPrResponse(string $title = 'fix: correct Postgres JSON syntax', ?string $body = null): array
+{
+    return [
+        'number' => 117,
+        'title' => $title,
+        'body' => $body,
+        'state' => 'open',
+        'user' => ['id' => 1, 'login' => 'jordanpartridge', 'avatar_url' => '', 'html_url' => '', 'type' => 'User'],
+        'html_url' => 'https://github.com/test/repo/pull/117',
+        'created_at' => '2026-04-06T10:00:00Z',
+        'updated_at' => '2026-04-06T10:00:00Z',
+        'closed_at' => null,
+        'merged_at' => null,
+        'merge_commit_sha' => null,
+        'draft' => false,
+        'additions' => 16,
+        'deletions' => 7,
+        'changed_files' => 2,
+        'assignee' => null,
+        'assignees' => [],
+        'requested_reviewers' => [],
+        'labels' => [],
+        'head' => [
+            'ref' => 'fix/watchdog',
+            'sha' => 'abc123',
+            'user' => ['id' => 1, 'login' => 'jordanpartridge', 'avatar_url' => '', 'html_url' => '', 'type' => 'User'],
+            'repo' => ['id' => 1, 'name' => 'repo', 'full_name' => 'test/repo', 'html_url' => '', 'private' => false],
+        ],
+        'base' => [
+            'ref' => 'main',
+            'sha' => 'def456',
+            'user' => ['id' => 1, 'login' => 'jordanpartridge', 'avatar_url' => '', 'html_url' => '', 'type' => 'User'],
+            'repo' => ['id' => 1, 'name' => 'repo', 'full_name' => 'test/repo', 'html_url' => '', 'private' => false],
+        ],
+    ];
+}
+
+function mockFilesResponse(): array
+{
+    return [
+        [
+            'sha' => 'aaa',
+            'filename' => 'app/Console/Commands/Watchdog.php',
+            'status' => 'modified',
+            'additions' => 10,
+            'deletions' => 5,
+            'changes' => 15,
+            'blob_url' => '',
+            'raw_url' => '',
+            'contents_url' => '',
+            'patch' => "@@ -60,4 +60,6 @@\n-                ->whereRaw(\"JSON_EXTRACT(data, '$.completedAt') IS NULL\")\n+                ->whereRaw(\"(data->>'completedAt') IS NULL\")",
+        ],
+        [
+            'sha' => 'bbb',
+            'filename' => 'app/Console/Commands/Reflect.php',
+            'status' => 'modified',
+            'additions' => 6,
+            'deletions' => 2,
+            'changes' => 8,
+            'blob_url' => '',
+            'raw_url' => '',
+            'contents_url' => '',
+            'patch' => "@@ -46,3 +46,5 @@\n-        \$channelId = \$this->openDm(\$token, \$jordanUserId);\n+        \$channelId = config('services.lexi.channel') ?: \$this->openDm(\$token, \$jordanUserId);",
+        ],
+    ];
+}
+
+function setupMockGitHub(): void
+{
+    $mockClient = new MockClient([
+        '*' => MockResponse::make(mockPrResponse()),
+    ]);
+
+    $connector = new Connector('fake-token');
+    $connector->withMockClient($mockClient);
+
+    PullRequests::setConnector($connector);
+}
+
+it('runs the full pipeline without judgment', function (): void {
+    $mockClient = new MockClient([
+        '*pulls/117' => MockResponse::make(mockPrResponse()),
+        '*pulls/117/files' => MockResponse::make(mockFilesResponse()),
+    ]);
+
+    $connector = new Connector('fake-token');
+    $connector->withMockClient($mockClient);
+    PullRequests::setConnector($connector);
+
+    $result = Review::for('test/repo', 117)
+        ->withoutJudgment()
+        ->analyze();
+
+    expect($result)
+        ->classification->toBe(Classification::BugFix)
+        ->repo->toBe('test/repo')
+        ->prNumber->toBe(117)
+        ->and($result->findings)->toBeEmpty()
+        ->and($result->verdict())->toBe(Verdict::Approve)
+        ->and($result->summary)->toContain('bug_fix');
+});
+
+it('catches convention violations in the pipeline', function (): void {
+    $mockClient = new MockClient([
+        '*pulls/117' => MockResponse::make(mockPrResponse('feat: add new service')),
+        '*pulls/117/files' => MockResponse::make([
+            [
+                'sha' => 'ccc',
+                'filename' => 'app/Services/NewService.php',
+                'status' => 'added',
+                'additions' => 20,
+                'deletions' => 0,
+                'changes' => 20,
+                'blob_url' => '',
+                'raw_url' => '',
+                'contents_url' => '',
+                'patch' => "@@ -0,0 +1,5 @@\n+<?php\n+class NewService {\n+    public function handle() {\n+        \$users = DB::table('users')->get();\n+    }\n+}",
+            ],
+        ]),
+    ]);
+
+    $connector = new Connector('fake-token');
+    $connector->withMockClient($mockClient);
+    PullRequests::setConnector($connector);
+
+    $result = Review::for('test/repo', 117)
+        ->withoutJudgment()
+        ->withRules([
+            new ForbiddenPattern('DB::', 'Use Eloquent, not DB:: facade'),
+        ])
+        ->analyze();
+
+    expect($result->findings)->toHaveCount(1)
+        ->and($result->findings->first()->message)->toBe('Use Eloquent, not DB:: facade')
+        ->and($result->classification)->toBe(Classification::Feature);
+});
+
+it('includes judgment call findings when enabled', function (): void {
+    $mockClient = new MockClient([
+        '*pulls/117' => MockResponse::make(mockPrResponse()),
+        '*pulls/117/files' => MockResponse::make(mockFilesResponse()),
+    ]);
+
+    $connector = new Connector('fake-token');
+    $connector->withMockClient($mockClient);
+    PullRequests::setConnector($connector);
+
+    JudgmentAgent::fake([
+        '[{"severity":"bug","file":"app/Console/Commands/Watchdog.php","lines":[62],"message":"Missing index on verb_snapshots for JSON query","confidence":0.75}]',
+    ]);
+
+    $result = Review::for('test/repo', 117)
+        ->analyze();
+
+    expect($result->findings)->toHaveCount(1)
+        ->and($result->findings->first()->source)->toBe('llm')
+        ->and($result->findings->first()->confidence)->toBe(0.75);
+});
+
+it('generates a useful summary', function (): void {
+    $mockClient = new MockClient([
+        '*pulls/117' => MockResponse::make(mockPrResponse()),
+        '*pulls/117/files' => MockResponse::make(mockFilesResponse()),
+    ]);
+
+    $connector = new Connector('fake-token');
+    $connector->withMockClient($mockClient);
+    PullRequests::setConnector($connector);
+
+    JudgmentAgent::fake(['[]']);
+
+    $result = Review::for('test/repo', 117)->analyze();
+
+    expect($result->summary)
+        ->toContain('bug_fix')
+        ->toContain('No issues found');
+});


### PR DESCRIPTION
## Summary
The pipeline is complete. `Review::for('owner/repo', 123)->analyze()` now runs the full flow:

1. Fetch PR via `conduit-ui/pr` (PullRequests::find)
2. Classify from title + file paths
3. Risk assessment (file count, churn, critical paths)
4. Convention checking against injected rules
5. Judgment call via LLM (optional)
6. Build ReviewResult with deterministic verdict

Also adds `reviewAndPost()` — analyze then post the verdict to GitHub via conduit-ui/pr's approve/requestChanges/comment builders.

## New API
```php
// Analyze only
$result = Review::for('owner/repo', 123)
    ->withRules([new ForbiddenPattern('DB::', 'Use Eloquent')])
    ->withConventions($claudeMd)
    ->analyze();

// Analyze + post review to GitHub
$result = Review::for('owner/repo', 123)
    ->withRules($rules)
    ->reviewAndPost();
```

## Stats
- 78 tests, 149 assertions
- Integration tests mock GitHub via Saloon MockClient

## Note
Structural diff (php-parser AST comparison) is wired but needs file-at-ref support from conduit-ui/pr to compare before/after source. Currently passes empty structural changes — will be connected in #10 follow-up.

Closes #2, closes #9